### PR TITLE
Provide test tools `maybe_async::test`

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,52 +21,31 @@ jobs:
           command: fmt
           args: --all -- --check
 
-      - name: check build (async)
+      - name: check build
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --features=is_async --all --bins --examples --tests
+          args: --features=is_sync,is_async --all --bins --examples --tests
 
-      - name: tests (async)
+      - name: tests
         uses: actions-rs/cargo@v1
         timeout-minutes: 40
         with:
           command: test
-          args: --features=is_async --all --no-fail-fast -- --nocapture
-
-      - name: check build (is_sync)
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --features=is_sync --all --bins --examples --tests
-
-      - name: tests (is_sync)
-        uses: actions-rs/cargo@v1
-        timeout-minutes: 40
-        with:
-          command: test
-          args: --features=is_sync --all --no-fail-fast -- --nocapture
+          args: --features=is_sync,is_async --all --no-fail-fast -- --nocapture
 
   doc:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
-      - name: doc (async)
+      - name: doc
         uses: actions-rs/cargo@v1
         env:
           RUSTDOCFLAGS: -Dwarnings
         with:
           command: doc
-          args: --features=is_async --all --no-deps
-
-      - name: doc (is_sync)
-        uses: actions-rs/cargo@v1
-        env:
-          RUSTDOCFLAGS: -Dwarnings
-        with:
-          command: doc
-          args: --features=is_sync --all --no-deps
+          args: --features=is_sync,is_async --all --no-deps
 
   publish:
     name: Publish Package

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -500,6 +500,31 @@ pub fn both(args: TokenStream, input: TokenStream) -> TokenStream {
     token.into()
 }
 
+/// `maybe_async::both` attribute macro
+///
+/// Can be applied to functions and items in impls.
+#[proc_macro_attribute]
+pub fn test_both(_args: TokenStream, input: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(input as Item);
+
+    let mut token = TokenStream2::new();
+
+    if cfg!(all(feature = "is_sync", feature = "is_async")) {
+        // We need a `clone` if both are enabled
+        token.extend(quote!(#[test]));
+        token.extend(convert_sync(item.clone()));
+        token.extend(quote!(#[tokio::test]));
+        token.extend(convert_async(item, false, false));
+    } else if cfg!(feature = "is_sync") {
+        token.extend(quote!(#[test]));
+        token.extend(convert_sync(item));
+    } else if cfg!(feature = "is_async") {
+        token.extend(quote!(#[tokio::test]));
+        token.extend(convert_async(item, false, false));
+    }
+    token.into()
+}
+
 /// `maybe_async::async_trait` attribute macro
 ///
 /// Can be applied to traits, trait impls.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,10 +25,7 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 
 use proc_macro2::{Span, TokenStream as TokenStream2};
-use syn::{
-    parse_macro_input, parse_quote, spanned::Spanned, AttributeArgs, Ident, ImplItem, Lit, Meta,
-    NestedMeta, TraitItem,
-};
+use syn::{parse_macro_input, parse_quote, Ident, ImplItem, TraitItem};
 
 use crate::{
     parse::Item,
@@ -500,11 +497,42 @@ pub fn both(args: TokenStream, input: TokenStream) -> TokenStream {
     token.into()
 }
 
-/// `maybe_async::both` attribute macro
+/// `maybe_async::test` attribute macro
 ///
-/// Can be applied to functions and items in impls.
+/// Applie to test cases.
+///
+/// ## Example
+///
+/// ```rust
+/// #[maybe_async::both]
+/// async fn some_function() -> bool {
+///     true
+/// }
+///
+/// #[maybe_async::test]
+/// async fn test_some_function() {
+///     let res = some_function().await;
+///     assert_eq!(res, true);
+/// }
+/// ```
+///
+/// Will generate:
+///
+/// ```rust
+/// #[test]
+/// fn test_some_function() {
+///     let res = some_function();
+///     assert_eq!(res, true);
+/// }
+///
+/// #[tokio::test]
+/// async fn test_some_function_async() {
+///     let res = some_function_async().await;
+///     assert_eq!(res, true);
+/// }
+/// ```
 #[proc_macro_attribute]
-pub fn test_both(_args: TokenStream, input: TokenStream) -> TokenStream {
+pub fn test(_args: TokenStream, input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as Item);
 
     let mut token = TokenStream2::new();
@@ -542,214 +570,4 @@ pub fn async_trait(args: TokenStream, input: TokenStream) -> TokenStream {
 
     let item = parse_macro_input!(input as Item);
     convert_trait(item, send).into()
-}
-
-/// Convert marked *async* codes to async.
-///
-/// Currently only used for testing.
-#[proc_macro_attribute]
-pub fn must_be_async(args: TokenStream, input: TokenStream) -> TokenStream {
-    let send = match args.to_string().replace(" ", "").as_str() {
-        "" | "Send" => true,
-        "?Send" => false,
-        _ => {
-            return syn::Error::new(Span::call_site(), "Only accepts `Send` or `?Send`")
-                .to_compile_error()
-                .into();
-        }
-    };
-    let item = parse_macro_input!(input as Item);
-    convert_async(item, send, false).into()
-}
-
-/// Convert marked *async* codes to sync.
-///
-/// Currently only used for testing.
-#[proc_macro_attribute]
-pub fn must_be_sync(_args: TokenStream, input: TokenStream) -> TokenStream {
-    let item = parse_macro_input!(input as Item);
-    convert_sync(item).into()
-}
-
-macro_rules! match_nested_meta_to_str_lit {
-    ($t:expr) => {
-        match $t {
-            NestedMeta::Lit(lit) => {
-                match lit {
-                    Lit::Str(s) => {
-                        s.value().parse::<TokenStream2>().unwrap()
-                    }
-                    _ => {
-                        return syn::Error::new(lit.span(), "expected meta or string literal").to_compile_error().into();
-                    }
-                }
-            }
-            NestedMeta::Meta(meta) => quote!(#meta)
-        }
-    };
-}
-
-/// Handy macro to unify test code of sync and async code
-///
-/// Since the API of both sync and async code are the same,
-/// with only difference that async functions must be awaited.
-/// So it's tedious to write unit sync and async respectively.
-///
-/// This macro helps unify the sync and async unit test code.
-/// Pass the condition to treat test code as sync as the first
-/// argument. And specify the condition when to treat test code
-/// as async and the lib to run async test, e.x. `async-std::test`,
-/// `tokio::test`, or any valid attribute macro.
-///
-/// **ATTENTION**: do not write await inside a assert macro
-///
-/// - Examples
-///
-/// ```rust
-/// #[maybe_async::both]
-/// async fn async_fn() -> bool {
-///     true
-/// }
-///
-/// #[maybe_async::test(
-///     // when to treat the test code as sync version
-///     feature="is_sync",
-///     // when to run async test
-///     async(all(feature="is_async", feature="async_std"), async_std::test),
-///     // you can specify multiple conditions for different async runtime
-///     async(all(feature="is_async", feature="tokio"), tokio::test)
-/// )]
-/// async fn test_async_fn() {
-///     let res = async_fn_async().await;
-///     assert_eq!(res, true);
-/// }
-///
-/// // Only run test in sync version
-/// #[maybe_async::test(feature = "is_sync")]
-/// async fn test_sync_fn() {
-///     let res = async_fn().await;
-///     assert_eq!(res, true);
-/// }
-/// ```
-///
-/// The above code is transcripted to the following code:
-///
-/// ```rust
-/// # use maybe_async::{must_be_async, must_be_sync};
-/// # #[maybe_async::both]
-/// # async fn async_fn() -> bool { true }
-///
-/// // convert to sync version when sync condition is met, keep in async version when corresponding
-/// // condition is met
-/// #[cfg_attr(feature = "is_sync", must_be_sync, test)]
-/// #[cfg_attr(
-///     all(feature = "is_async", feature = "async_std"),
-///     must_be_async,
-///     async_std::test
-/// )]
-/// #[cfg_attr(
-///     all(feature = "is_async", feature = "tokio"),
-///     must_be_async,
-///     tokio::test
-/// )]
-/// async fn test_async_fn() {
-///     let res = async_fn_async().await;
-///     assert_eq!(res, true);
-/// }
-///
-/// // force converted to sync function, and only compile on sync condition
-/// #[cfg(feature = "is_sync")]
-/// #[test]
-/// fn test_sync_fn() {
-///     let res = async_fn();
-///     assert_eq!(res, true);
-/// }
-/// ```
-#[proc_macro_attribute]
-pub fn test(args: TokenStream, input: TokenStream) -> TokenStream {
-    let attr_args = parse_macro_input!(args as AttributeArgs);
-    let input = TokenStream2::from(input);
-    if attr_args.is_empty() {
-        return syn::Error::new(
-            Span::call_site(),
-            "Arguments cannot be empty, at least specify the condition for sync code",
-        )
-        .to_compile_error()
-        .into();
-    }
-
-    // The first attributes indicates sync condition
-    let sync_cond = match_nested_meta_to_str_lit!(attr_args.first().unwrap());
-    let mut ts = quote!(#[cfg_attr(#sync_cond, maybe_async::must_be_sync, test)]);
-
-    // The rest attributes indicates async condition and async test macro
-    // only accepts in the forms of `async(cond, test_macro)`, but `cond` and
-    // `test_macro` can be either meta attributes or string literal
-    let mut async_token = Vec::new();
-    let mut async_conditions = Vec::new();
-    for async_meta in attr_args.into_iter().skip(1) {
-        match async_meta {
-            NestedMeta::Meta(meta) => match meta {
-                Meta::List(list) => {
-                    let name = list.path.segments[0].ident.to_string();
-                    if name.ne("async") {
-                        return syn::Error::new(
-                            list.path.span(),
-                            format!("Unknown path: `{}`, must be `async`", name),
-                        )
-                        .to_compile_error()
-                        .into();
-                    }
-                    if list.nested.len() == 2 {
-                        let async_cond =
-                            match_nested_meta_to_str_lit!(list.nested.first().unwrap());
-                        let async_test = match_nested_meta_to_str_lit!(list.nested.last().unwrap());
-                        let attr = quote!(
-                            #[cfg_attr(#async_cond, maybe_async::must_be_async, #async_test)]
-                        );
-                        async_conditions.push(async_cond);
-                        async_token.push(attr);
-                    } else {
-                        let msg = format!(
-                            "Must pass two metas or string literals like `async(condition, \
-                             async_test_macro)`, you passed {} metas.",
-                            list.nested.len()
-                        );
-                        return syn::Error::new(list.span(), msg).to_compile_error().into();
-                    }
-                }
-                _ => {
-                    return syn::Error::new(
-                        meta.span(),
-                        "Must be list of metas like: `async(condition, async_test_macro)`",
-                    )
-                    .to_compile_error()
-                    .into();
-                }
-            },
-            NestedMeta::Lit(lit) => {
-                return syn::Error::new(
-                    lit.span(),
-                    "Must be list of metas like: `async(condition, async_test_macro)`",
-                )
-                .to_compile_error()
-                .into();
-            }
-        };
-    }
-
-    async_token.into_iter().for_each(|t| ts.extend(t));
-    ts.extend(quote!( #input ));
-    if !async_conditions.is_empty() {
-        quote! {
-            #[cfg(any(#sync_cond, #(#async_conditions),*))]
-            #ts
-        }
-    } else {
-        quote! {
-            #[cfg(#sync_cond)]
-            #ts
-        }
-    }
-    .into()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,6 +497,25 @@ pub fn both(args: TokenStream, input: TokenStream) -> TokenStream {
     token.into()
 }
 
+/// `maybe_async::async_trait` attribute macro
+///
+/// Can be applied to traits, trait impls.
+#[proc_macro_attribute]
+pub fn async_trait(args: TokenStream, input: TokenStream) -> TokenStream {
+    let send = match args.to_string().replace(" ", "").as_str() {
+        "" | "Send" => true,
+        "?Send" => false,
+        _ => {
+            return syn::Error::new(Span::call_site(), "Only accepts `Send` or `?Send`")
+                .to_compile_error()
+                .into();
+        }
+    };
+
+    let item = parse_macro_input!(input as Item);
+    convert_trait(item, send).into()
+}
+
 /// `maybe_async::test` attribute macro
 ///
 /// Applie to test cases.
@@ -551,23 +570,4 @@ pub fn test(_args: TokenStream, input: TokenStream) -> TokenStream {
         token.extend(convert_async(item, false, false));
     }
     token.into()
-}
-
-/// `maybe_async::async_trait` attribute macro
-///
-/// Can be applied to traits, trait impls.
-#[proc_macro_attribute]
-pub fn async_trait(args: TokenStream, input: TokenStream) -> TokenStream {
-    let send = match args.to_string().replace(" ", "").as_str() {
-        "" | "Send" => true,
-        "?Send" => false,
-        _ => {
-            return syn::Error::new(Span::call_site(), "Only accepts `Send` or `?Send`")
-                .to_compile_error()
-                .into();
-        }
-    };
-
-    let item = parse_macro_input!(input as Item);
-    convert_trait(item, send).into()
 }

--- a/tests/unit-test-util.rs
+++ b/tests/unit-test-util.rs
@@ -3,26 +3,8 @@ async fn some_function() -> bool {
     true
 }
 
-#[maybe_async::test(feature = "is_sync", async(feature = "is_async", async_std::test))]
-async fn test_async_fn() {
+#[maybe_async::test]
+async fn test_fn() {
     let res = some_function().await;
-    assert_eq!(res, true);
-}
-
-#[maybe_async::test(feature = "is_sync", async(feature = "is_async", tokio::test))]
-async fn test_async_fn2() {
-    let res = some_function().await;
-    assert_eq!(res, true);
-}
-
-#[maybe_async::test(feature = "is_sync")]
-async fn test_async_fn3() {
-    let res = some_function().await;
-    assert_eq!(res, true);
-}
-
-#[maybe_async::test(feature = "is_sync")]
-async fn test_sync_fn() {
-    let res = some_function();
     assert_eq!(res, true);
 }


### PR DESCRIPTION
### Changes

- Provide test tools `maybe_async::test` to implement test cases for both sync & async. See example in comment.
- Remove old `maybe_async::test` and relevant functions.
- Change CI to test on both `is_sync` + `is_async` only, which is the main scene of our usage.